### PR TITLE
Define HUD timer constants to avoid ReferenceError

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,10 @@ const startPanel=document.getElementById('startPanel');
 const PH2=['¡Buen drift!','¡Limpio!','Nice Slide!','Good Drift!','¡Suave!','Clean lines!'];
 const PH3=['¡Increíble!','¡Brutal!','Insane Drift!','¡Dominio total!','Legendary!','¡Bestia!'];
 
+// Frecuencia del HUD (~10 Hz)
+let uiAccum = 0;
+const UI_DT = 1/10;
+
 /* ===== Touch Input (UNICO) ===== */
 const touchHUD = document.getElementById('touchHUD');
 const stickZone = document.getElementById('stickZone');


### PR DESCRIPTION
## Summary
- Declare `uiAccum` and `UI_DT` so `updateHUD` runs without ReferenceError.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3762d05748325ae6488aaaaa9e1b9